### PR TITLE
Make `impulse` a valid Nimble package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Impulse will be a collection of signal processing primitives for Nim.
 
+## FFT
+
+Currently this library only consists of an FFT module, which wraps
+[https://github.com/hayguen/pocketfft](PocketFFT), a header only C++
+library.
+
+To use it, please import the submodule directly. For example:
+
+```nim
+import impulse/fft/pocketfft
+import std / complex
+
+let dIn = @[1.0, 2.0, 1.0, -1.0, 1.5]
+var dOut = newSeq[Complex[float64]](dIn.len)
+
+let dInDesc = DataDesc[float64].init(
+  dIn[0].unsafeAddr, [dIn.len]
+)
+var dOutDesc = DataDesc[Complex[float64]].init(
+  dOut[0].addr, [dOut.len]
+)
+
+let fft = FFTDesc[float64].init(
+  axes = [0],
+  forward = true
+)
+
+fft.apply(dOutDesc, dInDesc)
+echo dIn
+echo dOut
+# @[1.0, 2.0, 1.0, -1.0, 1.5]
+# @[(4.5, 0.0), (2.081559480312316, -1.651098762732523), (-1.831559480312316, 1.608220406444071), (0.0, 0.0), (0.0, 0.0)]
+```
+
 
 ## License
 

--- a/impulse.nimble
+++ b/impulse.nimble
@@ -1,0 +1,11 @@
+# Package
+
+version       = "0.1.0"
+author        = "SciNim"
+description   = "Signal processing primitives (FFT, ...)"
+license       = "MIT"
+
+
+# Dependencies
+
+requires "nim >= 1.6.0"

--- a/impulse/fft/pocketfft.nim
+++ b/impulse/fft/pocketfft.nim
@@ -137,23 +137,23 @@ proc dst[T: SomeFloat](
 type
   DataDesc*[T] = object
     ## Descriptor of the data used in or out of the FFT
-    shape: Shape
-    stride: Stride
-    buf: ptr UncheckedArray[T]
+    shape*: Shape
+    stride*: Stride
+    buf*: ptr UncheckedArray[T]
 
-  FFTDesc[T] = object
+  FFTDesc*[T] = object
     ## Descriptor of the FFT
-    axes: Shape
-    scalingFactor: T
-    nthreads: uint
-    forward: bool
+    axes*: Shape
+    scalingFactor*: T
+    nthreads*: uint
+    forward*: bool
 
-  DCTDesc[T] = object
-    axes: Shape
-    dctType: range[1'i32..4'i32]
-    scalingFactor: T
-    nthreads: uint
-    ortho: bool
+  DCTDesc*[T] = object
+    axes*: Shape
+    dctType*: range[1'i32..4'i32]
+    scalingFactor*: T
+    nthreads*: uint
+    ortho*: bool
 
 func init*[T](_: type DataDesc[T],
               buffer: ptr T or ptr UncheckedArray[T],

--- a/impulse/fft/std_cpp.nim
+++ b/impulse/fft/std_cpp.nim
@@ -12,10 +12,10 @@
 # ############################################################
 
 type
-  CppUniquePtr* {.importcpp: "std::unique_ptr", header: "<memory>", byref.} [T] = object
-  CppVector* {.importcpp"std::vector", header: "<vector>", byref.} [T] = object
+  CppUniquePtr*[T] {.importcpp: "std::unique_ptr", header: "<memory>", byref.} = object
+  CppVector*[T] {.importcpp"std::vector", header: "<vector>", byref.} = object
   CppString* {.importcpp: "std::string", header: "<string>", byref.} = object
-  CppComplex* {.importcpp: "std::complex", header: "<complex>", bycopy.} [T] = object
+  CppComplex*[T] {.importcpp: "std::complex", header: "<complex>", bycopy.} = object
 
 proc newCppVector*[T](): CppVector[T] {.importcpp: "std::vector<'*0>()", header: "<vector>", constructor.}
 proc newCppVector*[T](size: int): CppVector[T] {.importcpp: "std::vector<'*0>(#)", header: "<vector>", constructor.}


### PR DESCRIPTION
Adds a proper Nimble package, to allow nimble to install it as a library.

Also adds a short section about the FFT part into the README and gives a short example. The FFT object related fields are now exported, too.